### PR TITLE
fixes to README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,23 @@
 # enable-a11y
+
 A list of demos to show how aria roles function with screen readers.
 
 ## Set up
-Nvm: https://github.com/nvm-sh/nvm#usage
-npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
-vnu: https://www.npmjs.com/package/vnu-jar
-lynx
-php
-npm install -g less-watch-compiler
 
-MAMP (OSX) or apache:
-https://www.mamp.info/en/mac/
-
-LAMP (Linux):
-https://www.linux.com/training-tutorials/easy-lamp-server-installation/
-
+nvm: https://github.com/nvm-sh/nvm#usage  
+npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm  
+vnu: https://www.npmjs.com/package/vnu-jar  
+lynx: https://etc.usf.edu/techease/4all/web-accessibility/the-lynx-text-web-browser/  
+php: https://www.php.net/downloads.php  
+less: `npm install -g less-watch-compiler`  
+MAMP (OSX) or Apache: https://www.mamp.info/en/mac/  
+LAMP (Linux): https://www.linux.com/training-tutorials/easy-lamp-server-installation/
 
 ## Style Notes
 
 1. All font-sizes are converted to rems. This is done via less.  If you want a font-size of 20px, then you would do the following:
 
-```
+```css
 div {
     font-size: (20/@px);
 }
@@ -32,12 +29,16 @@ The `@px` variable is set to 16rem, which is also the base font size
 
 ## Tests
 
+```bash
 sudo npm install axe-cli -g
 sudo npm install -g chromedriver
+```
 
 If there is a problem with running Chromedriver, because you have an error like "SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version XXX", then you should ensure your chromedriver is installed with the right version.
 
+```bash
 sudo npm install chromedriver --chromedriver_filepath=/path/to/chromedriver_mac64.zip
+```
 
 You can install the right zip file from here:
 
@@ -48,5 +49,6 @@ https://chromedriver.storage.googleapis.com/index.html
 https://stackoverflow.com/questions/71859550/session-not-created-this-version-of-chromedriver-only-supports-chrome-version-9
 
 ## References
-https://www.nvaccess.org/files/nvda/documentation/userGuide.html
+
+https://www.nvaccess.org/files/nvda/documentation/userGuide.html  
 https://dequeuniversity.com/screenreaders/survival-guide


### PR DESCRIPTION
I've made some fixes to the README markdown formatting (as well as adding a link for the lynx browser and php downloads).

Most of the changes revolve around appending two spaces to force a line break. Alternatively, a line break can be forced by adding another new line in between lines.

Also, I would suggest checking out the Links browser (different from Lynx). It's been very nice to use in my experience, and even has really good mouse support. You can check it out here: http://links.twibright.com/. You can install on debian-based systems with a simple `sudo apt install links`.