### PR TITLE
Add a hover style to drawer button controls (issue #46)

### DIFF
--- a/css/dropdown.css
+++ b/css/dropdown.css
@@ -34,6 +34,9 @@
   content: "";
   display: none;
 }
+.enable-drawer > .enable-drawer__button:hover {
+  text-decoration: underline;
+}
 .enable-drawer[open] > .enable-drawer__button,
 .enable-drawer .enable-drawer__button[aria-expanded="true"] {
   background-image: url("data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20version%3D%221.1%22%20id%3D%22Layer_1%22%20x%3D%220px%22%20y%3D%220px%22%20width%3D%2292px%22%20height%3D%2292px%22%20viewBox%3D%220%200%2092%2092%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20id%3D%22XMLID_38_%22%20d%3D%22M68%2050.5H24c-2.5%200-4.5-2-4.5-4.5s2-4.5%204.5-4.5h44c2.5%200%204.5%202%204.5%204.5s-2%204.5-4.5%204.5z%22%2F%3E%3Cmetadata%3E%3Crdf%3ARDF%20xmlns%3Ardf%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%22%20xmlns%3Ardfs%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%22%20xmlns%3Adc%3D%22http%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%22%3E%3Crdf%3ADescription%20about%3D%22https%3A%2F%2Ficonscout.com%2Flegal%23licenses%22%20dc%3Atitle%3D%22minus%22%20dc%3Adescription%3D%22minus%22%20dc%3Apublisher%3D%22Iconscout%22%20dc%3Adate%3D%222017-09-24%22%20dc%3Aformat%3D%22image%2Fsvg%2Bxml%22%20dc%3Alanguage%3D%22en%22%3E%3Cdc%3Acreator%3E%3Crdf%3ABag%3E%3Crdf%3Ali%3EAmit%20Jakhu%3C%2Frdf%3Ali%3E%3C%2Frdf%3ABag%3E%3C%2Fdc%3Acreator%3E%3C%2Frdf%3ADescription%3E%3C%2Frdf%3ARDF%3E%3C%2Fmetadata%3E%3C%2Fsvg%3E");

--- a/less/dropdown.less
+++ b/less/dropdown.less
@@ -22,6 +22,10 @@
    
     .remove-default-details-styles();
 
+    &:hover {
+      text-decoration: underline;
+    }
+
   }
 
 


### PR DESCRIPTION
Adds a simple underline hover style to the enable drawer button controls:

![2024-03-13_16-05-09 (1)](https://github.com/PublicisSapient/enable-a11y/assets/9080297/0e1dc64a-31cc-46c8-b716-2af8644a2fcc)


Relates to #46 