### PR TITLE
Tabs choose select on load

### DIFF
--- a/content/body/tabs.php
+++ b/content/body/tabs.php
@@ -79,7 +79,7 @@
         </a>
       </li>
       <li>
-        <a href="#heading__third-wave" class="enable-tab" data-owns="tabpanel__third-wave" data-tab-selected>
+        <a href="#heading__third-wave" class="enable-tab" data-owns="tabpanel__third-wave" data-tab-selected-on-load="true">
           Third Wave
         </a>
       </li>
@@ -184,6 +184,10 @@ const originalHTMLExample1 = document.getElementById('example1').innerHTML;
       "label": "Ensure classes are set up so roles will be assigned for JavaScript users",
       "highlight": "%INLINE%originalHTMLExample1 ||| class=\"enable-tablist\" ||| class=\"enable-tab\" ||| class=\"enable-tabpanel\"",
       "notes": "This is a basic list of links that answer to the headings of what will be the tabpanels when the JavaScript is executed.  Users who don't load the JavaScript (because of a network error or because they elected not to load it) will get this usable HTML.  Note that these links will "
+    },{
+      "label": "If needed, ensure the JavaScript can assign the tab that should be selected on load",
+      "highlight": "%INLINE%originalHTMLExample1 ||| data-tab-selected-on-load",
+      "notes": "In our implementation, we use the <code>data-tab-selected-on-load</code> attribute to determine which tab is selected on load.  If not included, the first tab is selected"
     },
     {
       "label": "Use data-owns to connect tabs with their tabpanel",

--- a/content/body/tabs.php
+++ b/content/body/tabs.php
@@ -74,12 +74,12 @@
         </a>
       </li>
       <li>
-        <a href="#heading__two-tone" class="enable-tab" data-owns="tabpanel__two-tone"  aria-selected="true">
+        <a href="#heading__two-tone" class="enable-tab" data-owns="tabpanel__two-tone"  >
           2 Tone
         </a>
       </li>
       <li>
-        <a href="#heading__third-wave" class="enable-tab" data-owns="tabpanel__third-wave">
+        <a href="#heading__third-wave" class="enable-tab" data-owns="tabpanel__third-wave" data-tab-selected>
           Third Wave
         </a>
       </li>

--- a/content/body/tabs.php
+++ b/content/body/tabs.php
@@ -74,7 +74,7 @@
         </a>
       </li>
       <li>
-        <a href="#heading__two-tone" class="enable-tab" data-owns="tabpanel__two-tone">
+        <a href="#heading__two-tone" class="enable-tab" data-owns="tabpanel__two-tone"  aria-selected="true">
           2 Tone
         </a>
       </li>

--- a/js/modules/es4/tabs.js
+++ b/js/modules/es4/tabs.js
@@ -116,11 +116,16 @@ const tabgroup = new function() {
     if (tabgroupEl.getAttribute("role") !== "tablist") {
       console.info('Roles do not exist. Adding');
       const tabEls = tabgroupEl.querySelectorAll(".enable-tab");
+      const tabElSelectedOnInit = tabgroupEl.querySelector(".enable-tab[data-tab-selected");
       tabgroupEl.setAttribute("role", "tablist");
       tabEls.forEach((tabEl) => {
         this.addTabRole(tabEl);
         this.addPresentationRoles(tabgroupEl, tabEl);
       });
+
+      if (tabElSelectedOnInit) {
+        tabElSelectedOnInit.setAttribute('aria-selected', 'true');
+      }
     }
   };
 

--- a/js/modules/es4/tabs.js
+++ b/js/modules/es4/tabs.js
@@ -116,7 +116,7 @@ const tabgroup = new function() {
     if (tabgroupEl.getAttribute("role") !== "tablist") {
       console.info('Roles do not exist. Adding');
       const tabEls = tabgroupEl.querySelectorAll(".enable-tab");
-      const tabElSelectedOnInit = tabgroupEl.querySelector(".enable-tab[data-tab-selected");
+      const tabElSelectedOnInit = tabgroupEl.querySelector(".enable-tab[data-tab-selected-on-load");
       tabgroupEl.setAttribute("role", "tablist");
       tabEls.forEach((tabEl) => {
         this.addTabRole(tabEl);

--- a/js/modules/es4/tabs.js
+++ b/js/modules/es4/tabs.js
@@ -28,12 +28,13 @@ const tabgroup = new function() {
     let activeTab = null;
     const activeHash = location.hash;
     const { keyboardOnlyInstructions } = tabgroupEl.dataset;
-
     this.addRoles(tabgroupEl);
+    const tabElSelectedOnInit = tabgroupEl.querySelector('[role="tab"][aria-selected="true"]');
+
+    console.log('tab selected', tabElSelectedOnInit);
 
     if (keyboardOnlyInstructions) {
       const tabEls = tabgroupEl.querySelectorAll('[role="tab"]');
-
       tabEls.forEach((el) =>
         el.setAttribute("aria-describedby", keyboardOnlyInstructions)
       );
@@ -52,7 +53,7 @@ const tabgroup = new function() {
       preventClickDefault: true,
 
       // This selects the first tab by default.
-      doSelectFirstOnInit: true,
+      doSelectFirstOnInit: !tabElSelectedOnInit,
 
       // This sets what the sr-only class is (default is .sr-only)
       visuallyHiddenClass: "sr-only",
@@ -62,28 +63,7 @@ const tabgroup = new function() {
       // this method is called afterwards.  It hides all the tabpanels
       // except for the one that checked tab is supposed to show (the
       // one with the ID on the tab's aria-controls attribute).
-      ariaCheckedCallback: function(
-        e,
-        currentlyCheckedEl
-      ) {
-        if (!currentlyCheckedEl) {
-          return;
-        }
-
-        const groupEl = currentlyCheckedEl.closest('[role="tablist"]');
-        const activePanelId = currentlyCheckedEl.getAttribute("aria-controls");
-        const panelEls =
-          groupEl.parentNode.querySelectorAll('[role="tabpanel"]');
-
-        for (let i = 0; i < panelEls.length; i++) {
-          var panel = panelEls[i];
-          if (panel.id === activePanelId) {
-            panel.classList.add("visible");
-          } else {
-            panel.classList.remove("visible");
-          }
-        }
-      },
+      ariaCheckedCallback: this.ariaCheckedCallback,
       activatedEventName: 'enable-selected'
     });
 
@@ -105,6 +85,28 @@ const tabgroup = new function() {
 
     if (activeTab) {
       activeTab.click();
+    } else if (tabElSelectedOnInit) {
+      this.ariaCheckedCallback(null, tabElSelectedOnInit);
+    }
+  }
+
+  this.ariaCheckedCallback = (e, currentlyCheckedEl) => {
+    if (!currentlyCheckedEl) {
+      return;
+    }
+
+    const groupEl = currentlyCheckedEl.closest('[role="tablist"]');
+    const activePanelId = currentlyCheckedEl.getAttribute("aria-controls");
+    const panelEls =
+      groupEl.parentNode.querySelectorAll('[role="tabpanel"]');
+
+    for (let i = 0; i < panelEls.length; i++) {
+      var panel = panelEls[i];
+      if (panel.id === activePanelId) {
+        panel.classList.add("visible");
+      } else {
+        panel.classList.remove("visible");
+      }
     }
   }
 

--- a/js/modules/tabs.js
+++ b/js/modules/tabs.js
@@ -117,7 +117,7 @@ const tabgroup = new function() {
     if (tabgroupEl.getAttribute("role") !== "tablist") {
       console.info('Roles do not exist. Adding');
       const tabEls = tabgroupEl.querySelectorAll(".enable-tab");
-      const tabElSelectedOnInit = tabgroupEl.querySelector(".enable-tab[data-tab-selected");
+      const tabElSelectedOnInit = tabgroupEl.querySelector(".enable-tab[data-tab-selected-on-load");
       tabgroupEl.setAttribute("role", "tablist");
       tabEls.forEach((tabEl) => {
         this.addTabRole(tabEl);

--- a/js/modules/tabs.js
+++ b/js/modules/tabs.js
@@ -117,11 +117,16 @@ const tabgroup = new function() {
     if (tabgroupEl.getAttribute("role") !== "tablist") {
       console.info('Roles do not exist. Adding');
       const tabEls = tabgroupEl.querySelectorAll(".enable-tab");
+      const tabElSelectedOnInit = tabgroupEl.querySelector(".enable-tab[data-tab-selected");
       tabgroupEl.setAttribute("role", "tablist");
       tabEls.forEach((tabEl) => {
         this.addTabRole(tabEl);
         this.addPresentationRoles(tabgroupEl, tabEl);
       });
+
+      if (tabElSelectedOnInit) {
+        tabElSelectedOnInit.setAttribute('aria-selected', 'true');
+      }
     }
   };
 

--- a/js/modules/tabs.js
+++ b/js/modules/tabs.js
@@ -29,12 +29,13 @@ const tabgroup = new function() {
     let activeTab = null;
     const activeHash = location.hash;
     const { keyboardOnlyInstructions } = tabgroupEl.dataset;
-
     this.addRoles(tabgroupEl);
+    const tabElSelectedOnInit = tabgroupEl.querySelector('[role="tab"][aria-selected="true"]');
+
+    console.log('tab selected', tabElSelectedOnInit);
 
     if (keyboardOnlyInstructions) {
       const tabEls = tabgroupEl.querySelectorAll('[role="tab"]');
-
       tabEls.forEach((el) =>
         el.setAttribute("aria-describedby", keyboardOnlyInstructions)
       );
@@ -53,7 +54,7 @@ const tabgroup = new function() {
       preventClickDefault: true,
 
       // This selects the first tab by default.
-      doSelectFirstOnInit: true,
+      doSelectFirstOnInit: !tabElSelectedOnInit,
 
       // This sets what the sr-only class is (default is .sr-only)
       visuallyHiddenClass: "sr-only",
@@ -63,28 +64,7 @@ const tabgroup = new function() {
       // this method is called afterwards.  It hides all the tabpanels
       // except for the one that checked tab is supposed to show (the
       // one with the ID on the tab's aria-controls attribute).
-      ariaCheckedCallback: function(
-        e,
-        currentlyCheckedEl
-      ) {
-        if (!currentlyCheckedEl) {
-          return;
-        }
-
-        const groupEl = currentlyCheckedEl.closest('[role="tablist"]');
-        const activePanelId = currentlyCheckedEl.getAttribute("aria-controls");
-        const panelEls =
-          groupEl.parentNode.querySelectorAll('[role="tabpanel"]');
-
-        for (let i = 0; i < panelEls.length; i++) {
-          var panel = panelEls[i];
-          if (panel.id === activePanelId) {
-            panel.classList.add("visible");
-          } else {
-            panel.classList.remove("visible");
-          }
-        }
-      },
+      ariaCheckedCallback: this.ariaCheckedCallback,
       activatedEventName: 'enable-selected'
     });
 
@@ -106,6 +86,28 @@ const tabgroup = new function() {
 
     if (activeTab) {
       activeTab.click();
+    } else if (tabElSelectedOnInit) {
+      this.ariaCheckedCallback(null, tabElSelectedOnInit);
+    }
+  }
+
+  this.ariaCheckedCallback = (e, currentlyCheckedEl) => {
+    if (!currentlyCheckedEl) {
+      return;
+    }
+
+    const groupEl = currentlyCheckedEl.closest('[role="tablist"]');
+    const activePanelId = currentlyCheckedEl.getAttribute("aria-controls");
+    const panelEls =
+      groupEl.parentNode.querySelectorAll('[role="tabpanel"]');
+
+    for (let i = 0; i < panelEls.length; i++) {
+      var panel = panelEls[i];
+      if (panel.id === activePanelId) {
+        panel.classList.add("visible");
+      } else {
+        panel.classList.remove("visible");
+      }
     }
   }
 


### PR DESCRIPTION
For the tab component, a request was made to select which tab is visible on first on load, which can be selected by setting the data-tab-selected-on-load attribute on the tab that should be selected.