### PR TITLE
Fixed #67: Needed to make folder for cache if not there.

### DIFF
--- a/services/getHeadlines.php
+++ b/services/getHeadlines.php
@@ -39,6 +39,10 @@ function json_cached_api_results($cache_file = null, $expires = null)
 
         // Remove cache file on error to avoid writing wrong xml
         if ($api_results && $json_results) {
+            if (!file_exists(dirname(__FILE__) . "/api-cache")) {
+                mkdir(dirname(__FILE__) . "/api-cache", 0777, true);
+            }
+
             file_put_contents($cache_file, $json_results);
         } elseif (file_exists($cache_file)) {
             unlink($cache_file);


### PR DESCRIPTION
file_put_contents does not create a folder structure when invoked and need to call mkdir to get that taken care of.