### PR TITLE
Fixed PHP binPath for windows users

### DIFF
--- a/bin/php-express/lib/PHPExpress/index.js
+++ b/bin/php-express/lib/PHPExpress/index.js
@@ -13,7 +13,10 @@ var PHPExpress = function (opts) {
             console.log(`Error was: ${error || stderr}`)
             process.exit(1);
         } else {
-            this.binPath = stdout.trim();
+            const stdoutVal = stdout.trim();
+            if (stdoutVal !== '') {
+                this.binPath = stdoutVal;
+            }
             console.log(`PHP found at ${this.binPath}`);
         }
     });


### PR DESCRIPTION
- Added check for empty binPath PHP string for windows users

Worked on with @gelamari 
Resolves https://github.com/PublicisSapient/enable-a11y/issues/113