### PR TITLE
chore: update code formatting cofigs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,15 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
 [*]
 charset = utf-8
 insert_final_newline = true
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = 2
 max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,22 +1,20 @@
 {
-    "phpVersion": "8.1",
-    "plugins": ["@prettier/plugin-php"],
-    "tabWidth": 4,
-    "bracketSameLine": true,
-    "printWidth": 80,
-    "singleQuote": false,
-    "overrides": [
-        {
-            "files": ["*.js"],
-            "options": {
-                "singleQuote": true
-            }
-        },
-        {
-            "files": ["*.md", "package.json", "package-lock.json"],
-            "options": {
-                "tabWidth": 2
-            }
-        }
-    ]
+  "phpVersion": "8.1",
+  "plugins": ["@prettier/plugin-php"],
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": ["*.js"],
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,5 @@
 {
+  "eslint.validate": ["json"],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
Includes following updates,

- Format files on save
- Look for editorconfig in the root
- Set indent size to 2
- Trim any whitespace characters preceding newline characters
- Print trailing commas wherever possible in multi-line comma-separated syntactic structures