### PR TITLE
Fix prettier precommit for images

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,6 @@
 
 # Source: https://prettier.io/docs/en/precommit.html#option-4-git-format-stagedhttpsgithubcomhallettjgit-format-staged
 
-npx git-format-staged -f 'prettier --ignore-unknown --stdin-filepath "{}"' '*.*'
+npx git-format-staged -f 'prettier --ignore-unknown --stdin-filepath "{}"' '*.js' '*.jsx' '*.less' '*.md' '*.json' '*.html' '*.php' '*.sh'
 
 # If you have issues when running the npx command in an IDE, you should try running the command in the terminal instead. This issue is due to the PATH values not being set as expected in the IDE in order for npx to be recognized. See https://stackoverflow.com/questions/67115897/vscode-github-desktop-pre-commit-hook-npx-command-not-found for more information.

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,10 @@ videos
 vtt
 bin/php-express
 **.ico
+**/*.jpeg
+**/*.jpg
+**/*.png
+**/*.webp
+**/*.mp4
+**/*.gif
+**/*.xcf


### PR DESCRIPTION
This is an attempt to handle the current issue with being unable to commit images due to the precommit code throwing an error when trying to format images. This PR does fix the issue with the images, but there may be other file types in the future that encounter the same kind of problem. I have tried to account for the known file types for now.

While ideally we wouldn't need to specify all of the file types that we want to be formatted in the pre-commit script, I have not found any other method that works. Additionally, the .prettierignore config _should_ already exclude the images, but the git-format-staged still seems to try to format the images first, which is where the problem is.