### PR TITLE
[fix] - first aria-slider has different stepper when used manually vs with keyboard

### DIFF
--- a/js/modules/enable-slider.js
+++ b/js/modules/enable-slider.js
@@ -422,14 +422,19 @@ const enableSlider = function (
             );
         });
 
-        $handle.addEventListener('touchstart', (e) => {
-            return this.handlePointerDown(
-                $handle,
-                $incrementor,
-                $decrementor,
-                e,
-            );
-        });
+        // Use passive: true for touchstart event listeners
+        $handle.addEventListener(
+            'touchstart',
+            (e) => {
+                return this.handlePointerDown(
+                    $handle,
+                    $incrementor,
+                    $decrementor,
+                    e,
+                );
+            },
+            { passive: true },
+        );
 
         window.addEventListener('resize', this.handleResize);
 
@@ -866,6 +871,10 @@ const enableSlider = function (
             );
         }
 
+        // Snap the value to the nearest increment
+        newVal = Math.round(newVal / this.inc) * this.inc;
+
+        // Clamp the value within the allowed range
         newVal = Math.max(startVal, Math.min(newVal, stopVal));
 
         this.positionHandle($handle, $handleButton, newVal);

--- a/js/modules/es4/enable-slider.js
+++ b/js/modules/es4/enable-slider.js
@@ -417,14 +417,19 @@ const enableSlider = function (
             );
         });
 
-        $handle.addEventListener('touchstart', (e) => {
-            return this.handlePointerDown(
-                $handle,
-                $incrementor,
-                $decrementor,
-                e,
-            );
-        });
+        // Use passive: true for touchstart event listeners
+        $handle.addEventListener(
+            'touchstart',
+            (e) => {
+                return this.handlePointerDown(
+                    $handle,
+                    $incrementor,
+                    $decrementor,
+                    e,
+                );
+            },
+            { passive: true },
+        );
 
         window.addEventListener('resize', this.handleResize);
 
@@ -861,6 +866,10 @@ const enableSlider = function (
             );
         }
 
+        // Snap the value to the nearest increment
+        newVal = Math.round(newVal / this.inc) * this.inc;
+
+        // Clamp the value within the allowed range
         newVal = Math.max(startVal, Math.min(newVal, stopVal));
 
         this.positionHandle($handle, $handleButton, newVal);


### PR DESCRIPTION
Fixed the issue where the first aria-slider having two different experiences when using with mouse click vs using voiceOver with keyboard.

on the slider.php page

<img width="890" alt="Screenshot 2025-03-26 at 1 39 15 PM" src="https://github.com/user-attachments/assets/cfdd6ab1-67da-4514-9c45-ed67718f5efc" />

Before ... the slider not moving correctly based on the data-range... which is 5 on mouse click


https://github.com/user-attachments/assets/707b3109-0cce-45cf-8b67-163a0019e517



Before ... the slider moving correctly based on the data-range... which is 5 on mouse click


https://github.com/user-attachments/assets/5f8e151b-e5be-4739-b2d6-0f8f6417ec84


